### PR TITLE
piSerial: fix the failure of Esys_StartAuthSession(ticket:REVPI-820)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+piserial (1.6.3) stable; urgency=medium
+
+  * Fix the failure after several times of tpm chip access.
+    The amount of transient entity of tpm chip is limit, which is
+    4 on flat. To make this work properly, this entity needs to be
+    removed after using with TPM2_FlushContext. It is not sufficient
+    to do this with TPM2_clear.
+
+ -- Zhi Han <z.han@kunbus.com> Tue, 29 Sep 2020 13:58:28 +0100
+
 piserial (1.6.2) stable; urgency=medium
 
   * Switch from Make to CMake.

--- a/src/read_ek.c
+++ b/src/read_ek.c
@@ -208,6 +208,12 @@ int read_ek(char *buf, int len)
 	    return 1;
     }
 
+    rc = Esys_FlushContext(esys_context, session_handle);
+    if (rc != TSS2_RC_SUCCESS) {
+	    LOG_ERROR("Esys_FlushContext FAILED! Response Code : 0x%x", rc);
+	    return 1;
+    }
+
     /*get ek pub from outPublic*/
     memcpy(buf, outPublic->publicArea.unique.rsa.buffer, len);
 


### PR DESCRIPTION
Signed-off-by: Zhi Han <z.han@kunbus.com>