### PR TITLE
Fix out of bound access to array

### DIFF
--- a/src/piSerialNum.c
+++ b/src/piSerialNum.c
@@ -114,7 +114,6 @@ char *getPassword(void)
         data &= 0x001f;
         sPassword[cnt] = sCode32[data];
     }
-    sPassword[10] = 0;
     
     return sPassword;
 }


### PR DESCRIPTION
In funtion getPassword() a static array is used to store and return the
password. After the password is stored the eleventh element of the array
is set to 0 - presumely to ensure a NULL terminated string.
However the array only has a size of 7. Furthermore since that array is
static and thus located in BSS segment, it is zeroed anyway.

So simply remove the errorneous access.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>