### PR TITLE
piSerial: remove the redundant calling of get_sn_i2c()

### DIFF
--- a/src/piSerialNum.c
+++ b/src/piSerialNum.c
@@ -49,8 +49,6 @@ char *getHostname(void)
 	sSalt[18] = 0xf2;
 	sSalt[5] = 0xd1;
 
-	get_sn_i2c();
-
 	sSalt[25] = 0x40;
 	sSalt[27] = i8uSernum[5];
 	sSalt[14] = 0x36;
@@ -93,8 +91,6 @@ char *getPassword(void)
 	static char sPassword[7];
 	char *sCode32 = "hancvo714xqwelm289rtz0356sdfgybp";
 	uint8_t i8uSalt[] = { 0x81, 0xae, 0xf2, 0x9d, 0x47, 0xd3 };
-
-	get_sn_i2c();
 
 	for (cnt = 0; cnt < 6; cnt++)
 	{


### PR DESCRIPTION
the get_sn_i2c() read the serial number from crypto chip through i2c
and store the serial number to a global variable. Later this serial
number is used for other purposes. Once the serial number is stored
in the global variable, it is not needed to be done again.

Signed-off-by: Zhi Han <z.han@kunbus.com>