### PR TITLE
piserial-1.4.6~0flat1 beta release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+piserial (1.4.6~0flat1) UNRELEASED; urgency=medium
+
+  * Add TPM support.
+  * Add RevolutionPi Flat support.
+  * Refactor argument handling.
+
+ -- Philipp Rosenberger <p.rosenberger@kunbus.com>  Tue, 20 Oct 2020 16:55:40 +0200
+
 piserial (1.4.5) stable; urgency=medium
 
   * Remove unused/wrong build dependency.


### PR DESCRIPTION
This beta release is targeted for the RevolutionPi Flat.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>