### PR TITLE
Send sleep sequence after command transmission

### DIFF
--- a/src/read_sernum.c
+++ b/src/read_sernum.c
@@ -94,6 +94,7 @@ int get_sn_i2c(const char *dev_node)
 	int r, i;
 	uint8_t buf[10];
 	uint8_t cnt;
+	int err = 0;
 
 	fd = open(dev_node, O_RDWR);
 	if (fd < 0)
@@ -138,8 +139,8 @@ int get_sn_i2c(const char *dev_node)
 		if (cnt >= 20)
 		{
 			// chip did not respond
-			close(fd);
-			return -3;
+			err = -3;
+			break;
 		}
 
 		cnt = 0;
@@ -153,8 +154,8 @@ int get_sn_i2c(const char *dev_node)
 		if (cnt >= 20)
 		{
 			// chip did not respond
-			close(fd);
-			return -4;
+			err = -4;
+			break;
 		}
 
 		for (cnt = 0; cnt < 4; cnt++)
@@ -164,8 +165,19 @@ int get_sn_i2c(const char *dev_node)
 		usleep(1000);
 	}
 
+	if (err)
+		usleep(1000);
+	/* Finally send a 'sleep sequence" to put the device in low power mode.
+	   This will prevent subsequent commands from failing due to watchdog
+	   expiration. */
+	buf[0] = 0x01;
+	if (write(fd, buf, 1) != 1) {
+		if (!err)
+			err = -5;
+	}
+
 	close(fd);
-	return 0;
+	return err;
 }
 
 int get_sn_tpm(const char *dev_node)


### PR DESCRIPTION
A watchdog counter starts after the ATECC508A has been woken up. After
expiration the device goes back to sleep regardless of whether an I/O
transmission or command execution is in progress.
If this happens while the serial number is read (e.g if the number is read
several consequtive times) the read number may be corrupted.
Prevent this by forcing the device back to sleep after we are done with
reading, since each time the device is woken up, the watchdog counter is
reset.

Signed-off-by: Lino Sanfilippo <l.sanfilippo@kunbus.com>