### PR TITLE
replace binary piSerial with script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
 
-project(piSerial)
+project(revpi-serial)
 
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,9 @@
-add_executable(piSerial piSerialNum.c read_sernum.c md5.c read_ek.c)
-target_link_libraries(piSerial tss2-esys tss2-tcti-device)
-install(TARGETS piSerial
+add_executable(revpi-serial piSerialNum.c read_sernum.c md5.c read_ek.c)
+target_link_libraries(revpi-serial tss2-esys tss2-tcti-device)
+install(TARGETS revpi-serial
   RUNTIME DESTINATION bin
 )
 
-install(PROGRAMS ks8851-set-mac revpi-factory-reset
+install(PROGRAMS ks8851-set-mac revpi-factory-reset piSerial
   DESTINATION sbin
 )

--- a/src/piSerial
+++ b/src/piSerial
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+while getopts ":shp" OPTION ; do
+	case ${OPTION} in
+	s)
+		;;
+	h)
+		;;
+	p)
+		;;
+	*)
+		echo 'usage: piSerial [-s|-h|-p]
+
+-s show serial number
+-h show hostname
+-p show inital password
+no argument: show all'
+
+		exit 0
+		;;
+	esac
+done
+
+if grep -q "revpi-flat" "/proc/device-tree/compatible"; then
+	sudo /usr/bin/revpi-serial -t /dev/tpm0 "$@";
+else
+	/usr/bin/revpi-serial -c /dev/i2c-1 "$@";
+fi
+
+exit $?

--- a/src/revpi-factory-reset
+++ b/src/revpi-factory-reset
@@ -51,16 +51,15 @@ if [ "$kernel" = 49 ] ; then
 fi
 
 piserial="/usr/bin/piSerial"
+piserial_args=""
 if [ "$ovl" == flat ]; then
 	if [ -c /dev/tpm0 ]; then
 		sn_exist=true
-		piserial_args="-t /dev/tpm0"
 	else
 		sn_exist=false
 	fi
 else
 	sn_exist=true
-	piserial_args=""
 fi
 
 if [ "$sn_exist" = true ]; then


### PR DESCRIPTION
change name of the original binary piSerial as revpi-serial, and a
script with name piSerial is created to replace the old binary.

in the script, do the parse /proc/device-tree/compatible to distinguish
the device type, and use the right parameter to access revpi-serial (was
piSerial before)

Signed-off-by: Zhi Han <z.han@kunbus.com>