### PR TITLE
change the path for piSerail calling

### DIFF
--- a/src/revpi-factory-reset
+++ b/src/revpi-factory-reset
@@ -50,7 +50,7 @@ if [ "$kernel" = 49 ] ; then
 	/bin/cp /boot/overlays/revpi-$ovl-dt-blob.dtbo /boot/dt-blob.bin 2>/dev/null
 fi
 
-piserial="/usr/bin/piSerial"
+piserial="/usr/sbin/piSerial"
 piserial_args=""
 if [ "$ovl" == flat ]; then
 	if [ -c /dev/tpm0 ]; then


### PR DESCRIPTION
as the piSerial currently needs the superuser(root) priviledge to
access the tpm chip, the /usr/sbin/ is now the right place for it.

However, this path change will cause all caller of piSerial do the
modifications, e.g webstatus

Signed-off-by: Zhi Han <z.han@kunbus.com>