### PR TITLE
revpi-factory-reset: Remove MAC addr handling for wlan on Flat [REVPI-1757]

### DIFF
--- a/src/revpi-factory-reset
+++ b/src/revpi-factory-reset
@@ -89,7 +89,7 @@ echo "$hostname" > /etc/hostname
 /bin/hostname "$hostname"
 
 # remove existing entries before writing new ones
-/bin/sed --follow-symlinks -r -i -e "/^dtparam=eth|wlan[0-9]_mac_/d" /boot/config.txt
+/bin/sed --follow-symlinks -r -i -e "/^dtparam=eth[0-9]_mac_/d" /boot/config.txt
 mac_hi="${mac:0:2}${mac:2:2}${mac:4:2}${mac:6:2}"
 mac_lo="${mac:8:2}${mac:10:2}"
 echo -e "MAC Address eth0:\t$mac_hi$mac_lo"
@@ -105,11 +105,6 @@ if [[ "$ovl" =~ ^(compact|connect|flat)$ ]] ; then
 		/usr/sbin/ks8851-set-mac eth1 "$mac_hi$mac_lo1"
 	fi
 	if [[ "$ovl" =~ ^flat$ ]] ; then
-		mac_lo2=$(( 0x${mac_lo1} + 1))
-		mac_lo2=$(/usr/bin/printf "%.4hx" "${mac_lo2}")
-		echo -e "MAC Address wlan0:\t$mac_hi$mac_lo2"
-		echo "dtparam=wlan0_mac_hi=0x${mac_hi}" >> /boot/config.txt
-		echo "dtparam=wlan0_mac_lo=0x${mac_lo2}" >> /boot/config.txt
 		ln -s /lib/systemd/system/hdmi-disable.service /etc/systemd/system/multi-user.target.wants/hdmi-disable.service
 		systemctl start hdmi-disable
 		echo "HDMI disabled. Use 'sudo systemctl disable hdmi-disable' and reboot to reenable HDMI."
@@ -130,11 +125,6 @@ if [[ $(readlink /proc/$$/fd/0) == /dev/tty* ]] ; then
 		/sbin/ifconfig eth1 down
 		/sbin/ifconfig eth1 hw ether "$mac_hi$mac_lo1"
 		/sbin/ifconfig eth1 up
-		if [[ "$ovl" =~ ^flat$ ]] ; then
-			/sbin/ifconfig wlan0 down
-			/sbin/ifconfig wlan0 hw ether "$mac_hi$mac_lo2"
-			/sbin/ifconfig wlan0 up
-		fi
 	fi
 else
 	echo "Reboot to activate the MAC Address"


### PR DESCRIPTION
Setting the MAC addr of the WiFi interface didn't work as expacted. The
patch to enable this feature has been removed from our kernel. Remove
the handling of the MAC address in the config.txt here as well.

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>