### PR TITLE
change format mac address for "ip link set" [REVPI-2218]

### DIFF
--- a/src/revpi-factory-reset
+++ b/src/revpi-factory-reset
@@ -99,13 +99,14 @@ echo -e "MAC Address eth0:\t$mac_hi$mac_lo"
 echo "dtparam=eth0_mac_hi=0x${mac_hi}" >> /boot/config.txt
 echo "dtparam=eth0_mac_lo=0x${mac_lo}" >> /boot/config.txt
 if [[ "$ovl" =~ ^($witheth1_devicetype_list)$ ]] ; then
-	mac_lo1=$(( 0x${mac_lo} + 1))
+	mac_lo1=$((0x${mac_lo} + 1))
 	mac_lo1=$(/usr/bin/printf "%.4hx" "${mac_lo1}")
-	echo -e "MAC Address eth1:\t$mac_hi$mac_lo1"
+	mac1="$mac_hi$mac_lo1"
+	echo -e "MAC Address eth1:\t$mac1"
 	echo "dtparam=eth1_mac_hi=0x${mac_hi}" >> /boot/config.txt
 	echo "dtparam=eth1_mac_lo=0x${mac_lo1}" >> /boot/config.txt
 	if [[ "$ovl" =~ ^compact$ ]] ; then
-		/usr/sbin/ks8851-set-mac eth1 "$mac_hi$mac_lo1"
+		/usr/sbin/ks8851-set-mac eth1 "$mac1"
 	fi
 	if [[ "$ovl" =~ ^flat$ ]] ; then
 		ln -s /lib/systemd/system/hdmi-disable.service /etc/systemd/system/multi-user.target.wants/hdmi-disable.service
@@ -126,7 +127,7 @@ if [[ $(readlink /proc/$$/fd/0) == /dev/tty* ]] ; then
 	ip link set eth0 up
 	if [[ "$ovl" =~ ^($witheth1_devicetype_list)$ ]] ; then
 		ip link set eth1 down
-		ip link set eth1 address "$mac_hi$mac_lo1"
+		ip link set eth1 address "$mac1"
 		ip link set eth1 up
 	fi
 else

--- a/src/revpi-factory-reset
+++ b/src/revpi-factory-reset
@@ -122,12 +122,14 @@ fi
 # activate MAC address immediately only if logged in on the console,
 # not via ssh, as the interface has to be taken down
 if [[ $(readlink /proc/$$/fd/0) == /dev/tty* ]] ; then
+	mac_colons="${mac:0:2}:${mac:2:2}:${mac:4:2}:${mac:6:2}:${mac:8:2}:${mac:10:2}"
 	ip link set eth0 down
-	ip link set eth0 address "$mac"
+	ip link set eth0 address "$mac_colons"
 	ip link set eth0 up
 	if [[ "$ovl" =~ ^($witheth1_devicetype_list)$ ]] ; then
+		mac_colons1="${mac1:0:2}:${mac1:2:2}:${mac1:4:2}:${mac1:6:2}:${mac1:8:2}:${mac1:10:2}"
 		ip link set eth1 down
-		ip link set eth1 address "$mac1"
+		ip link set eth1 address "$mac_colons1"
 		ip link set eth1 up
 	fi
 else


### PR DESCRIPTION
    Change the format of mac for "ip link set"

    The command "ip link set" accepts only the mac address in the
    format of "xx:xx:xx:xx:xx:xx" (case unsensitive), it was in the
    format of "xxxxxxxxxxxx" for ifconfig.

    As we shifted to tool "ip", it is needed to be changed accordingly.

    (FYI: the "ip link set" is only executed in real terminal login
     environment, not in ssh login.)

    Signed-off-by: Zhi Han <z.han@kunbus.com>
