### PR TITLE
Bump version to 2.1.0 [REVPI-2258]

### DIFF
--- a/src/revpi-serial.c
+++ b/src/revpi-serial.c
@@ -21,7 +21,7 @@
 #include "debug.h"
 #include "tpm2.h"
 
-#define PISERIAL_VERSION "2.0.2"
+#define PISERIAL_VERSION "2.1.0"
 
 const char lock_path[] = "/var/run/piserial.lock";
 


### PR DESCRIPTION
The package version is the same as the application version of piserial.
Bump the application version to 2.1.0 for the next package.

The minor version version is increased as the supporting of Core SE
and Connect SE is added.

Signed-off-by: Zhi Han <z.han@kunbus.com>