### PR TITLE
Release raspios/buster 2.1.0-1 [REVPI-2258]

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+piserial (2.1.0-1) buster; urgency=medium
+
+  * Refactory: Use variables to hold device type list
+  * Refactory: Use whiptail to interact with User
+  * Add device type Core SE
+  * Add device type Connect SE
+  * Make the factory resetting progress can be cancelled
+  * Remove the setting of mac during factory reset
+  * Bump version to 2.1.0
+
+ -- Zhi Han <z.han@kunbus.com>  Tue, 19 Apr 2022 15:25:14 +0200
+
 piserial (2.0.2-2) buster; urgency=medium
 
   * Replace depend of net-tools with iproute2

--- a/src/revpi-factory-reset
+++ b/src/revpi-factory-reset
@@ -15,11 +15,14 @@ mac="${mac,,}"		# downcase
 mac="${mac//-/}"	# remove dashes
 mac="${mac//:/}"	# remove colons
 
+full_devicetype_list="compact|connect|core|flat|core-se|connect-se"	# all suported devices
+witheth1_devicetype_list="compact|connect|flat|connect-se"	# devices with "eth1"
+
 if [ "$#" != 3 ] ||
-   ! [[ "$ovl" =~ ^(compact|connect|core|flat)$ ]] ||
+   ! [[ "$ovl" =~ ^($full_devicetype_list)$ ]] ||
    ! [[ "$ser" =~ ^[0-9]+$ ]] ||
    ! [[ "$mac" =~ ^[0-9a-f]{12}$ ]] ; then
-	echo -e 1>&2 "Usage: $(basename "$0") <compact|connect|core|flat> <serial> <mac addr>\n(see front plate)"
+	echo -e 1>&2 "Usage: $(basename "$0") <"$full_devicetype_list"> <serial> <mac addr>\n(see front plate)"
 	exit 1
 fi
 
@@ -48,7 +51,7 @@ else
 fi
 
 if [ "$kernel" = 49 ] ; then
-	/bin/sed --follow-symlinks -r -i -e "/^dtoverlay=revpi-(compact|connect|core|flat)/d" /boot/config.txt
+	/bin/sed --follow-symlinks -r -i -e "/^dtoverlay=revpi-($full_devicetype_list)/d" /boot/config.txt
 	echo "dtoverlay=revpi-$ovl" >> /boot/config.txt
 	/usr/bin/dtoverlay "revpi-$ovl"
 	/bin/cp "/boot/overlays/revpi-$ovl-dt-blob.dtbo" /boot/dt-blob.bin 2>/dev/null
@@ -95,7 +98,7 @@ mac_lo="${mac:8:2}${mac:10:2}"
 echo -e "MAC Address eth0:\t$mac_hi$mac_lo"
 echo "dtparam=eth0_mac_hi=0x${mac_hi}" >> /boot/config.txt
 echo "dtparam=eth0_mac_lo=0x${mac_lo}" >> /boot/config.txt
-if [[ "$ovl" =~ ^(compact|connect|flat)$ ]] ; then
+if [[ "$ovl" =~ ^($witheth1_devicetype_list)$ ]] ; then
 	mac_lo1=$(( 0x${mac_lo} + 1))
 	mac_lo1=$(/usr/bin/printf "%.4hx" "${mac_lo1}")
 	echo -e "MAC Address eth1:\t$mac_hi$mac_lo1"
@@ -115,21 +118,7 @@ if [ "$kernel" = 44 ] ; then
 	/bin/sed --follow-symlinks -r -i -e "s/ *smsc95xx.macaddr=[^ ]*//" -e "s/$/ smsc95xx.macaddr=$mac_cmdline/" /boot/cmdline.txt
 fi
 
-# activate MAC address immediately only if logged in on the console,
-# not via ssh, as the interface has to be taken down
-if [[ $(readlink /proc/$$/fd/0) == /dev/tty* ]] ; then
-	ip link set eth0 down
-	ip link set eth0 address "$mac"
-	ip link set eth0 up
-	if [[ "$ovl" =~ ^(compact|connect|flat)$ ]] ; then
-		ip link set eth1 down
-		ip link set eth1 address "$mac_hi$mac_lo1"
-		ip link set eth1 up
-	fi
-else
-	echo "Reboot to activate the MAC Address"
-fi
-
+echo "Reboot to activate the MAC Address"
 echo "Be sure to write down the password if you have lost the sticker"
 echo "on your RevPi!"
 

--- a/src/revpi-factory-reset.sh
+++ b/src/revpi-factory-reset.sh
@@ -9,19 +9,40 @@ if [ "$USER" != pi ] ; then
 	return
 fi
 
+# Environment variable for whiptail to set the color palette as the black color
+# for the background and grey color for the boxes.
+export NEWT_COLORS='root=,black entry=white,black'
+
 while [ ! -r /home/pi/.revpi-factory-reset ] ; do
-	echo
-	echo -n "Please enter the product (compact/connect/core/flat): "
-	read ovl
-	echo
-	echo Please enter the serial number and MAC address on the front plate
-	echo of your RevPi to reset the image to factory defaults:
-	echo
-	echo -ne "Serial:\t\t"
-	read ser
-	echo -ne "MAC Address:\t"
-	read mac
-	echo
+	clear
+	msg="Please select the Product Type:"
+	ovl=$(whiptail --notags --title "PRODUCT TYPE" --menu "$msg" 0 0 0 \
+		compact "Revolution Pi Compact" \
+		connect "Revolution Pi Connect" \
+		connect-se "Revolution Pi Connect SE" \
+		core "Revolution Pi Core" \
+		core-se "Revolution Pi Core SE" \
+		flat "Revolution Pi Flat" \
+		3>&1 1>&2 2>&3)
+	if [ "$?" == "1" ]; then
+		return
+	fi
+
+	msg="Please enter the Serial Number on the front plate of your RevPi:"
+	ser=$(whiptail --title "SERIAL NUMBER" --inputbox "$msg" 0 0 3>&1 1>&2 2>&3)
+	if [ "$?" == "1" ]; then
+		return
+	fi
+
+	msg="Please enter the MAC Address on the front plate of your RevPi:"
+	mac=$(whiptail --title "MAC ADDRESS" --inputbox "$msg" 0 0 "C83E-A7" 3>&1 1>&2 2>&3)
+	if [ "$?" == "1" ]; then
+		return
+	fi
+
 	# this creates /home/pi/.revpi-factory-reset on success:
-	/usr/bin/sudo /usr/sbin/revpi-factory-reset "$ovl" "$ser" "$mac"
+	/usr/bin/sudo /usr/sbin/revpi-factory-reset "$ovl" "$ser" "$mac" 2>/dev/null
+	if [ "$?" = 1 ]; then
+		$(whiptail --nocancel --title "ERROR" --msgbox "Invalid serial number or mac address" 0 0 3>&1 1>&2 2>&3)
+	fi
 done

--- a/src/revpi-serial.c
+++ b/src/revpi-serial.c
@@ -21,7 +21,7 @@
 #include "debug.h"
 #include "tpm2.h"
 
-#define PISERIAL_VERSION "2.0.2"
+#define PISERIAL_VERSION "2.1.0"
 
 const char lock_path[] = "/var/run/piserial.lock";
 


### PR DESCRIPTION
+  * Refactory: Use variables to hold device type list
+  * Refactory: Use whiptail to interact with User
+  * Add device type Core SE
+  * Add device type Connect SE
+  * Make the factory resetting progress can be cancelled
+  * Remove the setting of mac during factory reset
+  * Bump version to 2.1.0
+
+ -- Zhi Han <z.han@kunbus.com>  Tue, 19 Apr 2022 15:25:14 +0200
