### PR TITLE
Remove Core SE from factory reset

### DIFF
--- a/src/revpi-factory-reset
+++ b/src/revpi-factory-reset
@@ -15,7 +15,7 @@ mac="${mac,,}"		# downcase
 mac="${mac//-/}"	# remove dashes
 mac="${mac//:/}"	# remove colons
 
-full_devicetype_list="compact|connect|core|flat|core-se|connect-se"	# all suported devices
+full_devicetype_list="compact|connect|core|flat|connect-se"	# all suported devices
 witheth1_devicetype_list="compact|connect|flat|connect-se"	# devices with "eth1"
 
 if [ "$#" != 3 ] ||

--- a/src/revpi-factory-reset.sh
+++ b/src/revpi-factory-reset.sh
@@ -21,7 +21,6 @@ while [ ! -r /home/pi/.revpi-factory-reset ] ; do
 		connect "RevPi Connect(+) / Connect S" \
 		connect-se "RevPi Connect SE" \
 		core "RevPi Core / Core 3(+) / Core S" \
-		core-se "RevPi Core SE" \
 		flat "RevPi Flat" \
 		3>&1 1>&2 2>&3)
 	if [ "$?" == "1" ]; then


### PR DESCRIPTION
As Core SE will be always delivered with HAT EEPROM, the factory-reset
for it is not needed.

Signed-off-by: Zhi Han <z.han@kunbus.com>