### PR TITLE
Bump version to 2.1.1 [REVPI-2474]

### DIFF
--- a/src/revpi-serial.c
+++ b/src/revpi-serial.c
@@ -21,7 +21,7 @@
 #include "debug.h"
 #include "tpm2.h"
 
-#define PISERIAL_VERSION "2.1.0"
+#define PISERIAL_VERSION "2.1.1"
 
 const char lock_path[] = "/var/run/piserial.lock";
 


### PR DESCRIPTION
The package version is the same as the application version of piserial.
Bump the application version to 2.1.1 for the next package.