### PR TITLE
Adapted factory reset to CM1 overlay [REVPI-2563]

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,5 +16,5 @@ add_custom_target(lan9514.bin ALL
   DEPENDS /usr/bin/xxd
   VERBATIM)
 
-install(FILES lan9514.bin
+install(FILES lan9514.bin revpi-functions
   DESTINATION /usr/share/revpi)

--- a/src/revpi-factory-reset
+++ b/src/revpi-factory-reset
@@ -8,6 +8,8 @@
 # reset dtoverlay, password of user pi, machine-id, hostname, FQDN and
 # MAC address of a RevPi to factory defaults
 
+. /usr/share/revpi/revpi-functions
+
 ovl="$1"
 ser="$2"
 mac="$3"
@@ -24,6 +26,14 @@ if [ "$#" != 3 ] ||
    ! [[ "$mac" =~ ^[0-9a-f]{12}$ ]] ; then
 	echo -e 1>&2 "Usage: $(basename "$0") <"$full_devicetype_list"> <serial> <mac addr>\n(see front plate)"
 	exit 1
+fi
+
+if [ "$ovl" = "core" ]; then
+	if cm1-detection; then
+		echo "Compute Module 1 has been detected, core-cm1-overlay will be used"
+		echo "automatically."
+		ovl="core-cm1"
+	fi
 fi
 
 if [ "$(/usr/bin/id -u)" != 0 ] ; then

--- a/src/revpi-factory-reset
+++ b/src/revpi-factory-reset
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0
 #
-# Copyright: 2021 Kunbus GmbH
+# Copyright: 2021-2022 Kunbus GmbH
 #
 # resize root partition to fit the eMMC if it has more than 3.9 GByte;
 # reset dtoverlay, password of user pi, machine-id, hostname, FQDN and

--- a/src/revpi-factory-reset
+++ b/src/revpi-factory-reset
@@ -24,7 +24,7 @@ if [ "$#" != 3 ] ||
    ! [[ "$ovl" =~ ^($full_devicetype_list)$ ]] ||
    ! [[ "$ser" =~ ^[0-9]+$ ]] ||
    ! [[ "$mac" =~ ^[0-9a-f]{12}$ ]] ; then
-	echo -e 1>&2 "Usage: $(basename "$0") <"$full_devicetype_list"> <serial> <mac addr>\n(see front plate)"
+	echo -e 1>&2 "Usage: $(basename "$0") <$full_devicetype_list> <serial> <mac addr>\n(see front plate)"
 	exit 1
 fi
 

--- a/src/revpi-factory-reset.sh
+++ b/src/revpi-factory-reset.sh
@@ -52,7 +52,7 @@ while [ ! -r /home/pi/.revpi-factory-reset ] ; do
 
 	# this creates /home/pi/.revpi-factory-reset on success:
 	/usr/bin/sudo /usr/sbin/revpi-factory-reset "$ovl" "$ser" "$mac" 2>/dev/null
-	if [ "$?" = 1 ]; then
+	if [ "$?" == "1" ]; then
 		$(whiptail --nocancel --title "ERROR" --msgbox "Invalid serial number or mac address" 0 0 3>&1 1>&2 2>&3)
 	fi
 done

--- a/src/revpi-factory-reset.sh
+++ b/src/revpi-factory-reset.sh
@@ -53,6 +53,6 @@ while [ ! -r /home/pi/.revpi-factory-reset ] ; do
 	# this creates /home/pi/.revpi-factory-reset on success:
 	/usr/bin/sudo /usr/sbin/revpi-factory-reset "$ovl" "$ser" "$mac" 2>/dev/null
 	if [ "$?" == "1" ]; then
-		$(whiptail --nocancel --title "ERROR" --msgbox "Invalid serial number or mac address" 0 0 3>&1 1>&2 2>&3)
+		whiptail --nocancel --title "ERROR" --msgbox "Invalid serial number or mac address" 0 0
 	fi
 done

--- a/src/revpi-factory-reset.sh
+++ b/src/revpi-factory-reset.sh
@@ -5,6 +5,8 @@
 # Copyright: 2021 Kunbus GmbH
 #
 
+. /usr/share/revpi/revpi-functions
+
 if [ "$USER" != pi ] ; then
 	return
 fi
@@ -16,15 +18,24 @@ export NEWT_COLORS='root=,black entry=white,black'
 while [ ! -r /home/pi/.revpi-factory-reset ] ; do
 	clear
 	msg="Please select the Product Type:"
-	ovl=$(whiptail --notags --title "PRODUCT TYPE" --menu "$msg" 0 0 0 \
-		compact "RevPi Compact" \
-		connect "RevPi Connect(+) / Connect S" \
-		connect-se "RevPi Connect SE" \
-		core "RevPi Core / Core 3(+) / Core S" \
-		flat "RevPi Flat" \
-		3>&1 1>&2 2>&3)
-	if [ "$?" == "1" ]; then
-		return
+	if cm1-detection; then
+		ovl=$(whiptail --notags --title "PRODUCT TYPE" --menu "$msg" 0 0 0 \
+			core "RevPi Core (autodetected)" \
+			3>&1 1>&2 2>&3)
+		if [ "$?" == "1" ]; then
+			return
+		fi
+	else
+		ovl=$(whiptail --notags --title "PRODUCT TYPE" --menu "$msg" 0 0 0 \
+			compact "RevPi Compact" \
+			connect "RevPi Connect(+) / Connect S" \
+			connect-se "RevPi Connect SE" \
+			core "RevPi Core 3(+) / Core S" \
+			flat "RevPi Flat" \
+			3>&1 1>&2 2>&3)
+		if [ "$?" == "1" ]; then
+			return
+		fi
 	fi
 
 	msg="Please enter the Serial Number on the front plate of your RevPi:"

--- a/src/revpi-factory-reset.sh
+++ b/src/revpi-factory-reset.sh
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0
 #
-# Copyright: 2021 Kunbus GmbH
+# Copyright: 2021-2022 Kunbus GmbH
 #
 
 . /usr/share/revpi/revpi-functions

--- a/src/revpi-functions
+++ b/src/revpi-functions
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright: 2022 Kunbus GmbH
+#
+
+cm1-detection() {
+    grep -m 1 "model name" /proc/cpuinfo | grep -q v6l
+    return $?
+}


### PR DESCRIPTION
In order to relief the CPU on the older Compute Module, there is now a
distinctive overlay that uses the optimized DWC_OTG USB driver instead of DWC2.
CM1 hereby are autodetected during factory reset.

This PR had to be requested again, since it was formerly made from the wrong branch.