### PR TITLE
Fix working dir for lan9514 target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ install(FILES revpi-factory-reset.sh
 add_custom_target(lan9514.bin ALL
   COMMAND xxd -r lan9514.hex lan9514.bin
   DEPENDS /usr/bin/xxd
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src
   VERBATIM)
 
 install(FILES lan9514.bin revpi-functions


### PR DESCRIPTION
The working directory for the `lan9514.bin` target must be specified. Otherwise dpkg-buildpackage will faill because the file `lan9514.hex` can't be found.