### PR TITLE
Remove enabling and starting of hdmi-disable.service

### DIFF
--- a/src/revpi-factory-reset
+++ b/src/revpi-factory-reset
@@ -127,12 +127,6 @@ if ! "$with_hat_eeprom"; then
 		fi
 	fi
 
-	if [[ "$ovl" =~ ^flat$ ]] ; then
-		ln -s /lib/systemd/system/hdmi-disable.service /etc/systemd/system/multi-user.target.wants/hdmi-disable.service
-		systemctl start hdmi-disable
-		echo "HDMI disabled. Use 'sudo systemctl disable hdmi-disable' and reboot to reenable HDMI."
-	fi
-
 	echo "Reboot to activate the MAC Address"
 fi
 echo "Be sure to write down the password if you have lost the sticker"


### PR DESCRIPTION
The device types are now recongnizable in compatible string, thus the disabling of hdmi (power off the display) can be done in udev for Flat device during booting.

This makes the enabling and starting of the hdmi-disable.service unnecessary here in factory reset.

Signed-off-by: Zhi Han <z.han@kunbus.com>