### PR TITLE
Revert "Add dependency to xxd"

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: piserial
 Section: contrib/electronics
 Priority: optional
-Build-Depends: debhelper-compat (= 12), cmake, libtss2-dev (>= 2.1), xxd
+Build-Depends: debhelper-compat (= 12), cmake, libtss2-dev (>= 2.1)
 Standards-Version: 4.5.1
 Maintainer: KUNBUS GmbH <support@kunbus.com>
 Homepage: https://revolution.kunbus.com/

--- a/debian/control
+++ b/debian/control
@@ -10,11 +10,8 @@ Package: piserial
 Architecture: any
 Depends: ${shlibs:Depends},
  ${misc:Depends},
- ethtool,
- parted,
  e2fsprogs,
  libraspberrypi-bin,
- iproute2,
  sudo
 Description: Revolution Pi serial number utility
  Retrieve the RevPi's serial number and generate the factory-default password.


### PR DESCRIPTION
As the lan95xx tools have been moved out, the dependency to xxd is not needed.

This reverts commit 2ae2501fbd5666c5eac18c1fed63e45f50abf39b.