### PR TITLE
Update SPDX license headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 cmake_minimum_required(VERSION 3.13)
 
 project(revpi-serial)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
+
 add_executable(revpi-serial revpi-serial.c atecc508a.c tpm2.c)
 target_link_libraries(revpi-serial tss2-esys tss2-tcti-device)
 install(TARGETS revpi-serial

--- a/src/atecc508a.c
+++ b/src/atecc508a.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 /*
  * Copyright: 2021 KUNBUS GmbH

--- a/src/atecc508a.h
+++ b/src/atecc508a.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 /*
  * Copyright: 2021 KUNBUS GmbH

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 /*
  * Copyright: 2021 KUNBUS GmbH

--- a/src/piSerial
+++ b/src/piSerial
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# SPDX-License-Identifier: GPL-2.0
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright: 2021 KUNBUS GmbH
 #

--- a/src/revpi-serial.c
+++ b/src/revpi-serial.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 /*
  * Copyright: 2022 KUNBUS GmbH

--- a/src/tpm2.c
+++ b/src/tpm2.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 /*
  * Copyright: 2021 KUNBUS GmbH

--- a/src/tpm2.h
+++ b/src/tpm2.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 /*
  * Copyright: 2021 KUNBUS GmbH


### PR DESCRIPTION
The GPL-2.0 identifier is deprecated since SPDX version 3.0. See https://spdx.org/licenses/ section "Deprecated License Identifiers"

Use GPL-2.0-or-later as defined here:
https://spdx.org/licenses/GPL-2.0-or-later.html

Signed-off-by: Philipp Rosenberger <p.rosenberger@kunbus.com>