### PR TITLE
Prefer TPM whenever it's available

### DIFF
--- a/src/piSerial
+++ b/src/piSerial
@@ -29,7 +29,7 @@ while getopts ":spv" OPTION ; do
 	esac
 done
 
-if grep -q "revpi-flat" "/proc/device-tree/compatible"; then
+if [ -e /dev/tpm0 ] ; then
 	exec sudo /usr/sbin/revpi-serial -t /dev/tpm0 "$@";
 else
 	exec sudo /usr/sbin/revpi-serial -c /dev/i2c-1 "$@";


### PR DESCRIPTION
piSerial uses the TPM on the RevPi Flat and the I2C-attached ATECC508A on all other RevPi products.

However the RevPi Connect 4 likewises uses a TPM and it is expected that all forthcoming products are.  To avoid having to add the name of each new product, prefer the TPM whenever it's available and fall back to the ATECC508A otherwise.

The only downside of this approach is that if the TPM is inaccessible on boot (e.g. due to broken hardware), piSerial will attempt to access a non-existent ATECC508A.